### PR TITLE
Adding windows starteverything command

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "generate:pwa:assets:icons": "pwa-asset-generator apps/app/src/assets/logos/schadre-logo-only.png apps/app/src/assets/pwa --favicon --icon-only --padding \"20px\" --mstile --maskable --manifest apps/app/src/manifest.webmanifest",
     "generate:pwa:assets:splashes": "pwa-asset-generator apps/app/src/assets/logos/schadre-logo-only.png apps/app/src/assets/pwa --favicon --splash-only --padding \"150px\" --mstile --maskable --manifest apps/app/src/manifest.webmanifest",
     "host:app": "http-server dist/apps/app",
-    "start:everything": "$TERMINAL yarn start:api:dev & $TERMINAL yarn start:app:dev & $TERMINAL yarn start:emulators & "
+    "start:everything": "$TERMINAL yarn start:api:dev & $TERMINAL yarn start:app:dev & $TERMINAL yarn start:emulators & ",
+    "start:everything:windows": "start cmd /k \"yarn start:api:dev\" & start cmd /k \"yarn start:emulators\" & start cmd /k \"yarn start:app:dev\""
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Added the `yarn start:everything:windows` command so that people who have their environment set up on windows can easily start their development servers and emulators.
Has been tested on one windows pc.